### PR TITLE
Use ncipollo/release-action@v1 instead to release docker-scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,52 +20,10 @@ jobs:
       - name: Build Cross
         run: make cross
 
-      - name: Zip it
-        run: |
-          zip --junk-paths ./dist/docker-scan_darwin_amd64
-          zip --junk-paths ./dist/docker-scan_linux_amd64
-          zip --junk-paths ./dist/docker-scan_windows_amd64
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Ship it
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
+          artifacts: "dist/*"
           prerelease: true
-
-      - name: Upload macOS plugin
-        id: upload-release-asset-macOS
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./docker-scan_darwin_amd64.zip
-          asset_name: docker-scan_darwin_amd64.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload linux plugin
-        id: upload-release-asset-linux
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./docker-scan_linux_amd64.zip
-          asset_name: docker-scan_linux_amd64.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Windows plugin
-        id: upload-release-asset-windows
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./docker-scan_windows_amd64.zip
-          asset_name: docker-scan_windows_amd64.zip
-          asset_content_type: application/octet-stream
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Silvin Lubecki <silvin.lubecki@docker.com>

![image](https://user-images.githubusercontent.com/31478878/83545599-bc3dbd80-a4ff-11ea-9584-c3f48336776c.png)
