### PR TITLE
Use env.Patch to overload env variable in e2e tests

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	dockerConfigFile "github.com/docker/cli/cli/config/configfile"
-	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
 
@@ -84,11 +83,4 @@ func createSymLink(binaryName, sourceDir, configDir string) {
 	if err := os.Symlink(filepath.Join(sourceDir, binaryName), filepath.Join(configDir, binaryName)); err != nil {
 		panic(err)
 	}
-}
-
-func overloadEnvVariable(t *testing.T, envVar string, value string) func() {
-	initialValue := os.Getenv(envVar)
-	err := os.Setenv(envVar, value)
-	assert.NilError(t, err)
-	return  func() { _ = os.Setenv(envVar, initialValue) }
 }

--- a/e2e/scan_test.go
+++ b/e2e/scan_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 	"gotest.tools/v3/fs"
 	"gotest.tools/v3/icmd"
 )
@@ -18,7 +19,7 @@ func TestScanFailsNoAuthentication(t *testing.T) {
 	// create Snyk config file with empty token
 	homeDir := createSnykConfFile(t, "")
 	defer homeDir.Remove()
-	defer overloadEnvVariable(t, "HOME", homeDir.Path()) ()
+	defer env.Patch(t, "HOME", homeDir.Path())()
 
 	cmd, configDir, cleanup := dockerCli.createTestCmd()
 	defer cleanup()
@@ -61,7 +62,7 @@ func TestScanSucceedWithSnyk(t *testing.T) {
 	// create Snyk config file with empty token
 	homeDir := createSnykConfFile(t, "valid-token")
 	defer homeDir.Remove()
-	defer overloadEnvVariable(t, "HOME", homeDir.Path()) ()
+	defer env.Patch(t, "HOME", homeDir.Path())()
 
 	cmd, _, cleanup := dockerCli.createTestCmd()
 	defer cleanup()

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker-scan/config"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 	"gotest.tools/v3/icmd"
 
 	"github.com/docker/docker-scan/internal"
@@ -17,7 +18,7 @@ import (
 func TestVersionSnykUserBinary(t *testing.T) {
 	// Add user snyk binary to the $PATH
 	path := os.Getenv("PATH")
-	defer overloadEnvVariable(t, "PATH", fmt.Sprintf("%s:%s", "/root/e2e", path))()
+	defer env.Patch(t, "PATH", fmt.Sprintf("%s:%s", "/root/e2e", path))()
 
 	cmd, configDir, cleanup := dockerCli.createTestCmd()
 	defer cleanup()


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

![image](https://user-images.githubusercontent.com/705411/83804640-bd611d00-a6ae-11ea-8ea4-eea24554c305.png)
