### PR TITLE
Create ~/.docker/scan directory if it doesn't exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,10 @@ func SaveConfigFile(conf Config) error {
 	if err != nil {
 		return err
 	}
+	if err = os.MkdirAll(filepath.Join(cliConfig.Dir(), "scan"), 0744); err != nil {
+		return errors.Wrap(err, "failed to create docker scan configuration directory")
+	}
+
 	path := filepath.Join(cliConfig.Dir(), "scan", "config.json")
 	return errors.Wrap(ioutil.WriteFile(path, out, os.FileMode(644)), "failed to write docker scan configuration file")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,59 @@
+/*
+   Copyright 2020 Docker Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	dockerConfigFile "github.com/docker/cli/cli/config/configfile"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
+)
+
+func TestSaveConfigFile(t *testing.T) {
+	configDir, err := ioutil.TempDir("", "config")
+	assert.NilError(t, err)
+	defer os.RemoveAll(configDir) //nolint:errcheck
+
+	configFilePath := filepath.Join(configDir, "config.json")
+	dockerConfig := dockerConfigFile.ConfigFile{
+		CLIPluginsExtraDirs: []string{
+			"cli-plugins",
+		},
+		Filename: configFilePath,
+	}
+	configFile, err := os.Create(configFilePath)
+	assert.NilError(t, err)
+	//nolint:errcheck
+	defer configFile.Close()
+	err = json.NewEncoder(configFile).Encode(dockerConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	defer env.Patch(t, "DOCKER_CONFIG", configDir)
+
+	config := Config{
+		Path:  configDir,
+		Optin: false,
+	}
+	assert.NilError(t, SaveConfigFile(config))
+}


### PR DESCRIPTION
Fix #77 

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>
![image](https://user-images.githubusercontent.com/705411/87956928-e77c6c00-caaf-11ea-9e7e-60071022c3e6.png)
