### PR TITLE
Switch release to manual github action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: release
-
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch'
+        required: true
+        default: 'main'
+      tag:
+        description: 'Release Tag'
+        required: true
 
 jobs:
   release:
@@ -16,9 +21,6 @@ jobs:
 
       - name: Docker version
         run: docker version
-
-      - name: TagName
-        uses: olegtarasov/get-tag@v2
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,3 +51,4 @@ jobs:
           prerelease: true
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>


**- What I did**
Update the release flow to be trigger manually from github action workflow by specifying branch to use and the version tag


**- How to verify it**
https://github.com/glours/docker-scan/runs/891590920?check_suite_focus=true

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/87984873-f4628500-cada-11ea-947f-27c769f0ef02.png)

