### PR TITLE
Fix file mode setup when writting the config.json file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,5 +63,5 @@ func SaveConfigFile(conf Config) error {
 	}
 
 	path := filepath.Join(cliConfig.Dir(), "scan", "config.json")
-	return errors.Wrap(ioutil.WriteFile(path, out, os.FileMode(644)), "failed to write docker scan configuration file")
+	return errors.Wrap(ioutil.WriteFile(path, out, os.FileMode(0644)), "failed to write docker scan configuration file")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,9 +51,13 @@ func TestSaveConfigFile(t *testing.T) {
 
 	defer env.Patch(t, "DOCKER_CONFIG", configDir)
 
-	config := Config{
+	expected := Config{
 		Path:  configDir,
 		Optin: false,
 	}
-	assert.NilError(t, SaveConfigFile(config))
+	assert.NilError(t, SaveConfigFile(expected))
+
+	result, err := ReadConfigFile()
+	assert.NilError(t, err)
+	assert.Equal(t, result, expected)
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**- What I did**
Setup correctly the file mode to write `config.json` file and avoid permission issues

**- How to verify it**
Add a test assertion which checks that we can read the file after writing it

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/88043433-b6527900-cb4d-11ea-84c5-67adb1e3b7e5.png)

