### PR TITLE
Change the destination directory of binaries for release

### DIFF
--- a/.github/workflows/release-weekly-build.yml
+++ b/.github/workflows/release-weekly-build.yml
@@ -4,6 +4,10 @@ on:
     - cron: "0 0 * * SUN"
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch'
+        required: true
+        default: 'main'
       tag:
         description: 'Release Tag'
 
@@ -33,6 +37,8 @@ jobs:
 
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
+        with:
+          ${{ github.event.inputs.branch }}
 
       - name: Golang cache
         uses: actions/cache@v1


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

We don't use `cross` target to build the binaries but the local platform `build` one, so all the binaries are available in `./bin` directory

![image](https://user-images.githubusercontent.com/705411/88718544-5a29bf00-d122-11ea-9373-9341022c2c39.png)
