### PR TITLE
Use platform specific binary names for release

### DIFF
--- a/.github/workflows/release-weekly-build.yml
+++ b/.github/workflows/release-weekly-build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Ship it
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/docker-scan-macos-latest/*, dist/docker-scan-linux-latest/*, dist/docker-scan-windows-latest/*"
+          artifacts: "dist/*/*"
           prerelease: true
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # SCAN
 ####
 FROM scratch AS scan
-COPY --from=build /go/src/github.com/docker/scan-cli-plugin/bin/docker-scan /docker-scan
+ARG TARGETOS
+COPY --from=build /go/src/github.com/docker/scan-cli-plugin/bin/docker-scan_${TARGETOS} /docker-scan_${TARGETOS}
 
 ####
 # CROSS_BUILD
@@ -126,6 +127,8 @@ RUN make -f builder.Makefile download
 # E2E
 ####
 FROM builder AS e2e
+ARG TARGETOS
+ARG TARGETARCH
 ARG SNYK_DESKTOP_VERSION=1.332.0
 ENV SNYK_DESKTOP_VERSION=${SNYK_DESKTOP_VERSION}
 ARG SNYK_USER_VERSION=1.334.0
@@ -142,6 +145,6 @@ COPY --from=download /go/bin/gotestsum /usr/local/bin/gotestsum
 # install docker CLI
 COPY --from=cli /usr/local/bin/docker /usr/local/bin/docker
 # install docker-scan plugin
-COPY --from=cross-build /go/src/github.com/docker/scan-cli-plugin/dist/docker-scan_linux_amd64 ./bin/docker-scan
-RUN chmod +x ./bin/docker-scan
+COPY --from=cross-build /go/src/github.com/docker/scan-cli-plugin/dist/docker-scan_${TARGETOS}_${TARGETARCH} ./bin/docker-scan_${TARGETOS}_${TARGETARCH}
+RUN chmod +x ./bin/docker-scan_${TARGETOS}_${TARGETARCH}
 CMD ["make", "-f", "builder.Makefile", "e2e"]

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ validate-go-mod: ## Validate go.mod and go.sum are up-to-date
 	@docker build . --target check-go-mod
 
 .PHONY: validate
-validate: validate-headers validate-go-mod ## Validate sources
+validate: validate-go-mod validate-headers ## Validate sources
 
 .PHONY: help
 help: ## Show help

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -18,11 +18,13 @@ LDFLAGS := "-s -w \
   -X $(PKG_NAME)/internal.GitCommit=$(COMMIT) \
   -X $(PKG_NAME)/internal.Version=$(TAG_NAME)"
 GO_BUILD = $(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
-BINARY:=docker-scan
+BINARY=docker-scan
+PLATFORM_BINARY:=$(BINARY)_$(GOOS)_amd64
 SNYK_DOWNLOAD_NAME:=snyk-linux
 SNYK_BINARY:=snyk
 PWD:=$(shell pwd)
 ifeq ($(GOOS),windows)
+	PLATFORM_BINARY=docker-scan_$(GOOS)_amd64.exe
 	BINARY=docker-scan.exe
 	SNYK_DOWNLOAD_NAME:=snyk-win.exe
 	SNYK_BINARY=snyk.exe
@@ -50,7 +52,7 @@ lint:
 e2e:
 	mkdir -p docker-config/scan
 	mkdir -p docker-config/cli-plugins
-	cp ./bin/${BINARY} docker-config/cli-plugins/${BINARY}
+	cp ./bin/${PLATFORM_BINARY} docker-config/cli-plugins/${BINARY}
 	$(VARS) gotestsum ./e2e $(RUN_TEST) -- -ldflags=$(LDFLAGS)
 
 .PHONY: test-unit
@@ -65,7 +67,7 @@ cross:
 .PHONY: build
 build:
 	mkdir -p bin
-	$(GO_BUILD) -o bin/$(BINARY) ./cmd/docker-scan
+	$(GO_BUILD) -o bin/$(PLATFORM_BINARY) ./cmd/docker-scan
 
 # For multi-platform (windows,macos,linux) github actions
 .PHONY: download


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

[Link to draft release with well named binaries ](https://github.com/docker/scan-cli-plugin/releases/tag/untagged-6be59722ffa108a5fedd)
[Link to action which produces the release](https://github.com/docker/scan-cli-plugin/actions/runs/189095767)

![image](https://user-images.githubusercontent.com/705411/88970854-61cc9d80-d2b3-11ea-875d-bf0067a20657.png)
