### PR TITLE
Add linter to the release and weekly build workflow

### DIFF
--- a/.github/workflows/release-weekly-build.yml
+++ b/.github/workflows/release-weekly-build.yml
@@ -64,14 +64,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Golang cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Download binaries
         run: make -f builder.Makefile download
 


### PR DESCRIPTION
Also remove golang cache on release workflow as it doesn't handle `workflow_dispatch` event

**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/31478878/89666349-812e8080-d8da-11ea-9808-221c0b357d68.png)
