### PR TITLE
Add SNYK_CFG_DISABLESUGGESTIONS env variable to disable suggestion at…

### DIFF
--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -177,7 +177,7 @@ func (s *snykProvider) Version() (string, error) {
 
 func (s *snykProvider) newCommand(arg ...string) *exec.Cmd {
 	cmd := exec.CommandContext(s.context, s.path, arg...)
-	cmd.Env = append(os.Environ(), "NO_UPDATE_NOTIFIER=1")
+	cmd.Env = append(os.Environ(), "NO_UPDATE_NOTIFIER=1", "SNYK_CFG_DISABLESUGGESTIONS=1")
 	return cmd
 }
 


### PR DESCRIPTION
… the end of the scan

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

closes #55 

**- What I did**
Use the new `SNYK_CFG_DISABLESUGGESTIONS` env variable to hide the suggestions in Snyk CLI output


**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/91152683-928bd100-e6bf-11ea-8aa5-e2515e951365.png)

