### PR TITLE
Use snyk container test command instead of snyk test --docker one to …

### DIFF
--- a/e2e/scan_test.go
+++ b/e2e/scan_test.go
@@ -37,7 +37,8 @@ import (
 
 const (
 	ImageWithVulnerabilities      = "alpine:3.10.0"
-	ImageWithoutVulnerabilities   = "dockerscanci/scratch:1.0"          // FROM scratch
+	ImageWithoutVulnerabilities   = "hello-world"
+	InvalidImage                  = "dockerscanci/scratch:1.0"          // FROM scratch
 	ImageBaseImageVulnerabilities = "dockerscanci/base-image-vulns:1.0" // FROM alpine:3.10.0
 )
 
@@ -125,6 +126,12 @@ func TestScanWithSnyk(t *testing.T) {
 			contains: "no vulnerable paths found",
 		},
 		{
+			name:     "invalid-docker-archive",
+			image:    InvalidImage,
+			exitCode: 2,
+			contains: "Invalid Docker archive",
+		},
+		{
 			name:     "image-with-vulnerabilities",
 			image:    ImageWithVulnerabilities,
 			exitCode: 1,
@@ -134,7 +141,7 @@ func TestScanWithSnyk(t *testing.T) {
 			name:     "invalid-image-name",
 			image:    "scratch",
 			exitCode: 2,
-			contains: "image was not found locally and pulling failed",
+			contains: "manifest unknown",
 		},
 	}
 	for _, testCase := range testCases {
@@ -168,6 +175,12 @@ func TestScanJsonOutput(t *testing.T) {
 			name:     "image-without-vulnerabilities",
 			image:    ImageWithoutVulnerabilities,
 			exitCode: 0,
+			isEmpty:  true,
+		},
+		{
+			name:     "invalid-docker-archive",
+			image:    InvalidImage,
+			exitCode: 2,
 			isEmpty:  true,
 		},
 		{

--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -45,7 +45,7 @@ type snykProvider struct {
 // NewSnykProvider returns a Snyk implementation of scan provider
 func NewSnykProvider(ops ...SnykProviderOps) (Provider, error) {
 	provider := snykProvider{
-		flags: []string{"test", "--docker"},
+		flags: []string{"container", "test"},
 	}
 	for _, op := range ops {
 		if err := op(&provider); err != nil {


### PR DESCRIPTION
…fix windows issues

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**- What I did**
Change the shell out command to Snyk CLI from `snyk test --docker [...flags] image` to `snyk container test [...flags] image` to fix issues on windows 

**- How to verify it**
e2e tests should be green

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/91324796-bdab1900-e7c2-11ea-9084-fa654255e1e7.png)

