### PR TITLE
Add all UTMs env vars 

### DIFF
--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -129,6 +129,11 @@ func (s *snykProvider) Authenticate(token string) error {
 		}
 	}
 	cmd := s.newCommand("auth", token)
+	cmd.Env = append(cmd.Env,
+		"SNYK_UTM_MEDIUM=Partner",
+		"SNYK_UTM_SOURCE=Docker",
+		"SNYK_UTM_CAMPAIGN=Docker-Desktop-2020",
+		"SNYK_INTEGRATION_NAME=DOCKER_DESKTOP")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return checkCommandErr(cmd.Run())


### PR DESCRIPTION
It's needed by the snyk CLI to forward to the auth landing page so they can better track the campaign.

⚠️ We won't send `SNYK_INTEGRATION_VERSION` asked by snyk.

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/92118076-47c43480-edf6-11ea-8fcf-8ffbb7ff77f7.png)

