### PR TITLE
Fix Snyk utm env vars

### DIFF
--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -132,8 +132,7 @@ func (s *snykProvider) Authenticate(token string) error {
 	cmd.Env = append(cmd.Env,
 		"SNYK_UTM_MEDIUM=Partner",
 		"SNYK_UTM_SOURCE=Docker",
-		"SNYK_UTM_CAMPAIGN=Docker-Desktop-2020",
-		"SNYK_INTEGRATION_NAME=DOCKER_DESKTOP")
+		"SNYK_UTM_CAMPAIGN=Docker-Desktop-2020")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return checkCommandErr(cmd.Run())
@@ -188,7 +187,10 @@ func (s *snykProvider) Version() (string, error) {
 
 func (s *snykProvider) newCommand(arg ...string) *exec.Cmd {
 	cmd := exec.CommandContext(s.context, s.path, arg...)
-	cmd.Env = append(os.Environ(), "NO_UPDATE_NOTIFIER=true", "SNYK_CFG_DISABLESUGGESTIONS=true")
+	cmd.Env = append(os.Environ(),
+		"NO_UPDATE_NOTIFIER=true",
+		"SNYK_CFG_DISABLESUGGESTIONS=true",
+		"SNYK_INTEGRATION_NAME=DOCKER_DESKTOP")
 	return cmd
 }
 


### PR DESCRIPTION
**- What I did**
* Fix Snyk update notification: we erased the env vars using os.Environ() instead of appending to the cmd.Env.
* Add the env var SNYK_INTEGRATION_NAME=DOCKER_DESKTOP for all the snyk calls

**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/31478878/93860156-f0133d80-fcbe-11ea-88f5-76139b383b74.png)
