### PR TITLE
Change assertion on error message to fix windows version of TestVersi…

### DIFF
--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/env"
 	"gotest.tools/v3/icmd"
 
@@ -93,7 +94,7 @@ Provider:   %s
 }
 
 func TestVersionWithoutSnykOrConfig(t *testing.T) {
-	cmd, configDir, cleanup := dockerCli.createTestCmd()
+	cmd, _, cleanup := dockerCli.createTestCmd()
 	defer cleanup()
 
 	// docker scan --version should fail with a clean error
@@ -101,11 +102,8 @@ func TestVersionWithoutSnykOrConfig(t *testing.T) {
 	output := icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		ExitCode: 1,
 	}).Combined()
-	expected := fmt.Sprintf(
-		`failed to read docker scan configuration file. Please restart Docker Desktop: open %s/scan/config.json: no such file or directory
-`,
-		configDir)
-	assert.Equal(t, output, expected)
+	expected := "failed to read docker scan configuration file. Please restart Docker Desktop"
+	assert.Assert(t, is.Contains(output, expected))
 }
 
 func getProviderVersion(env string) string {


### PR DESCRIPTION
…onWithoutSnykOrConfig test


**- What I did**
Update assertion of `TestVersionWithoutSnykOrConfig` to fix the windows version of the test

**- How I did it**
With my little fingers and my keyboard

**- How to verify it**
We should be able to do the `v0.3.4` release 😄 

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/97441175-b6220080-1928-11eb-881d-49608f705786.png)

