### PR TITLE
add support of --fail-on Snyk flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,23 @@ Licenses:          enabled
 Tested 200 dependencies for known issues, found 157 issues.
 ``` 
 
+If your image has unfixed issues, and you need to bypass the error code, you can use the `--fail-on` flag.
+```console
+$ docker scan --fail-on=upgradable docker-scan:e2e
+...
+Organization:      docker-desktop-test
+Package manager:   deb
+Project name:      docker-image|docker-scan
+Docker image:      docker-scan:e2e
+Platform:          linux/amd64
+Licenses:          enabled
+
+Tested 200 dependencies for known issues, found 158 issues.
+
+❯ echo $?
+0
+```
+
 ### Provider Authentication
 
 If you have an existing Snyk account, you can directly use your auth token  

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -8,6 +8,8 @@ Options:
       --dependency-tree   Show dependency tree with scan results
       --exclude-base      Exclude base image from vulnerability scanning
                           (requires --file)
+      --fail-on string    Only fail when there are vulnerabilities that
+                          can be fixed (all|upgradable|patchable)
   -f, --file string       Dockerfile associated with image, provides more
                           detailed results
       --json              Output results in JSON format

--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -136,6 +136,14 @@ func WithDependencyTree() SnykProviderOps {
 	}
 }
 
+// WithFailOn only fail when there are vulnerabilities that can be fixed
+func WithFailOn(failOn string) SnykProviderOps {
+	return func(provider *snykProvider) error {
+		provider.flags = append(provider.flags, "--fail-on="+failOn)
+		return nil
+	}
+}
+
 func (s *snykProvider) Authenticate(token string) error {
 	if token != "" {
 		if _, err := uuid.Parse(token); err != nil {


### PR DESCRIPTION
fix #129 

**- What I did**
Add a new `--fail-on` flag to support the same flag in Snyk CLI

**- How I did it**
Add a new flag, check the 3 possible values and add this when needed to the Snyk CLI

**- How to verify it**
Run e2e tests, they checks both values and the change of the exit code when the flag is set

**- Description for the changelog**
Add support of Snyk `--fail-on` flag

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/100254343-790a5780-2f42-11eb-9108-f4a2629d9a32.png)

