### PR TITLE
add support of --severity-threshold Snyk flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,45 @@ Licenses:          enabled
 
 Tested 200 dependencies for known issues, found 157 issues.
 ``` 
+If you want to only display some level of vulnerabilities, the `--severity` flag allows you to choose between 3 levels of
+vulnerabilities `low`,`medium` or `high`. By using this tag you will only report vulnerabilities of the provided level
+ or higher.
+ 
+ ```console
+$ docker scan --severity=medium docker-scan:e2e 
+./bin/docker-scan_darwin_amd64 scan --severity=medium docker-scan:e2e
+
+Testing docker-scan:e2e...
+
+✗ Medium severity vulnerability found in sqlite3/libsqlite3-0
+  Description: Divide By Zero
+  Info: https://snyk.io/vuln/SNYK-DEBIAN10-SQLITE3-466337
+  Introduced through: gnupg2/gnupg@2.2.12-1+deb10u1, subversion@1.10.4-1+deb10u1, mercurial@4.8.2-1+deb10u1
+  From: gnupg2/gnupg@2.2.12-1+deb10u1 > gnupg2/gpg@2.2.12-1+deb10u1 > sqlite3/libsqlite3-0@3.27.2-3
+  From: subversion@1.10.4-1+deb10u1 > subversion/libsvn1@1.10.4-1+deb10u1 > sqlite3/libsqlite3-0@3.27.2-3
+  From: mercurial@4.8.2-1+deb10u1 > python-defaults/python@2.7.16-1 > python2.7@2.7.16-2+deb10u1 > python2.7/libpython2.7-stdlib@2.7.16-2+deb10u1 > sqlite3/libsqlite3-0@3.27.2-3
+
+✗ Medium severity vulnerability found in sqlite3/libsqlite3-0
+  Description: Uncontrolled Recursion
+...
+✗ High severity vulnerability found in binutils/binutils-common
+  Description: Missing Release of Resource after Effective Lifetime
+  Info: https://snyk.io/vuln/SNYK-DEBIAN10-BINUTILS-403318
+  Introduced through: gcc-defaults/g++@4:8.3.0-1
+  From: gcc-defaults/g++@4:8.3.0-1 > gcc-defaults/gcc@4:8.3.0-1 > gcc-8@8.3.0-6 > binutils@2.31.1-16 > binutils/binutils-common@2.31.1-16
+  From: gcc-defaults/g++@4:8.3.0-1 > gcc-defaults/gcc@4:8.3.0-1 > gcc-8@8.3.0-6 > binutils@2.31.1-16 > binutils/libbinutils@2.31.1-16 > binutils/binutils-common@2.31.1-16
+  From: gcc-defaults/g++@4:8.3.0-1 > gcc-defaults/gcc@4:8.3.0-1 > gcc-8@8.3.0-6 > binutils@2.31.1-16 > binutils/binutils-x86-64-linux-gnu@2.31.1-16 > binutils/binutils-common@2.31.1-16
+  and 4 more...
+
+Organization:      docker-desktop-test
+Package manager:   deb
+Project name:      docker-image|docker-scan
+Docker image:      docker-scan:e2e
+Platform:          linux/amd64
+Licenses:          enabled
+
+Tested 200 dependencies for known issues, found 37 issues.
+```  
 
 If your image has unfixed issues, and you need to bypass the error code, you can use the `--fail-on` flag.
 ```console

--- a/cmd/docker-scan/main.go
+++ b/cmd/docker-scan/main.go
@@ -70,6 +70,7 @@ type options struct {
 	forceOptIn     bool
 	forceOptOut    bool
 	failOn         string
+	severity       string
 }
 
 func newScanCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
@@ -99,6 +100,7 @@ func newScanCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.forceOptIn, "accept-license", false, "Accept using a third party scanning provider")
 	cmd.Flags().BoolVar(&flags.forceOptOut, "reject-license", false, "Reject using a third party scanning provider")
 	cmd.Flags().StringVar(&flags.failOn, "fail-on", "", "Only fail when there are vulnerabilities that can be fixed (all|upgradable|patchable)")
+	cmd.Flags().StringVar(&flags.severity, "severity", "", "Only report vulnerabilities of provided level or higher (low|medium|high)")
 
 	return cmd
 }
@@ -133,6 +135,12 @@ func configureProvider(ctx context.Context, dockerCli command.Streams, flags opt
 			return nil, fmt.Errorf("--fail-on takes only 'all', 'upgradable' or 'patchable' values")
 		}
 		opts = append(opts, provider.WithFailOn(flags.failOn))
+	}
+	if flags.severity != "" {
+		if flags.severity != "low" && flags.severity != "medium" && flags.severity != "high" {
+			return nil, fmt.Errorf("--severity takes only 'low', 'medium' or 'high' values")
+		}
+		opts = append(opts, provider.WithSeverity(flags.severity))
 	}
 	return provider.NewSnykProvider(opts...)
 }

--- a/e2e/scan_test.go
+++ b/e2e/scan_test.go
@@ -297,6 +297,43 @@ func TestScanWithFailOnBadValue(t *testing.T) {
 		Err:      "--fail-on takes only 'all', 'upgradable' or 'patchable' values"})
 }
 
+func TestScanWithSeverity(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("Can't run on this ci platform (windows containers or no engine installed)")
+	}
+	_, cleanFunction := createSnykConfFile(t, os.Getenv("E2E_TEST_AUTH_TOKEN"))
+	defer cleanFunction()
+
+	cmd, configDir, cleanup := dockerCli.createTestCmd()
+	defer cleanup()
+
+	createScanConfigFile(t, configDir)
+
+	cmd.Command = dockerCli.Command("scan", "--accept-license", "--severity=medium", ImageWithVulnerabilities)
+	output := icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 1}).Combined()
+	assert.Assert(t, strings.Contains(output, "alpine:3.10.0")) // beginning of the dependency tree
+	assert.Assert(t, cmp.Regexp("found .* issues", output))
+	assert.Assert(t, !strings.Contains(output, "Low severity"))
+}
+
+func TestScanWithSeverityBadValue(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("Can't run on this ci platform (windows containers or no engine installed)")
+	}
+	_, cleanFunction := createSnykConfFile(t, os.Getenv("E2E_TEST_AUTH_TOKEN"))
+	defer cleanFunction()
+
+	cmd, configDir, cleanup := dockerCli.createTestCmd()
+	defer cleanup()
+
+	createScanConfigFile(t, configDir)
+
+	cmd.Command = dockerCli.Command("scan", "--accept-license", "--severity=unsupportedValue", ImageWithVulnerabilities)
+	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+		ExitCode: 1,
+		Err:      "--severity takes only 'low', 'medium' or 'high' values"})
+}
+
 func createSnykConfFile(t *testing.T, token string) (*fs.Dir, func()) {
 	content := fmt.Sprintf(`{"api" : "%s"}`, token)
 	homeDir := fs.NewDir(t, t.Name(),

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -17,6 +17,8 @@ Options:
                           optional token (with --token), or web base
                           token if empty
       --reject-license    Reject using a third party scanning provider
+      --severity string   Only report vulnerabilities of provided level
+                          or higher (low|medium|high)
       --token string      Authentication token to login to the third
                           party scanning provider
       --version           Display version of the scan plugin

--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -144,6 +144,14 @@ func WithFailOn(failOn string) SnykProviderOps {
 	}
 }
 
+// WithSeverity only reports vulnerabilities of the provided level or higher
+func WithSeverity(severity string) SnykProviderOps {
+	return func(provider *snykProvider) error {
+		provider.flags = append(provider.flags, "--severity-threshold="+severity)
+		return nil
+	}
+}
+
 func (s *snykProvider) Authenticate(token string) error {
 	if token != "" {
 		if _, err := uuid.Parse(token); err != nil {


### PR DESCRIPTION
- What I did
Add a new `--severity` flag to support the `--severity-threshold` in Snyk CLI

- How I did it
Add a new flag, check the 3 possible values and add this when needed to the Snyk CLI

- How to verify it
Run e2e tests, they checks both values and the change of the output when the flag is set

- Description for the changelog
Add support of Snyk `--severity-threshold` flag


**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/705411/100381841-2c924b00-301a-11eb-823d-24f932c97fda.png)
