### PR TITLE
remove --fails-on flag which is always exiting with a 0 code when use…

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,23 +261,6 @@ Licenses:          enabled
 Tested 200 dependencies for known issues, found 37 issues.
 ```  
 
-If your image has unfixed issues, and you need to bypass the error code, you can use the `--fail-on` flag.
-```console
-$ docker scan --fail-on=upgradable docker-scan:e2e
-...
-Organization:      docker-desktop-test
-Package manager:   deb
-Project name:      docker-image|docker-scan
-Docker image:      docker-scan:e2e
-Platform:          linux/amd64
-Licenses:          enabled
-
-Tested 200 dependencies for known issues, found 158 issues.
-
-❯ echo $?
-0
-```
-
 ### Provider Authentication
 
 If you have an existing Snyk account, you can directly use your auth token  

--- a/cmd/docker-scan/main.go
+++ b/cmd/docker-scan/main.go
@@ -69,7 +69,6 @@ type options struct {
 	showVersion    bool
 	forceOptIn     bool
 	forceOptOut    bool
-	failOn         string
 	severity       string
 }
 
@@ -99,7 +98,6 @@ func newScanCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.showVersion, "version", false, "Display version of the scan plugin")
 	cmd.Flags().BoolVar(&flags.forceOptIn, "accept-license", false, "Accept using a third party scanning provider")
 	cmd.Flags().BoolVar(&flags.forceOptOut, "reject-license", false, "Reject using a third party scanning provider")
-	cmd.Flags().StringVar(&flags.failOn, "fail-on", "", "Only fail when there are vulnerabilities that can be fixed (all|upgradable|patchable)")
 	cmd.Flags().StringVar(&flags.severity, "severity", "", "Only report vulnerabilities of provided level or higher (low|medium|high)")
 
 	return cmd
@@ -129,12 +127,6 @@ func configureProvider(ctx context.Context, dockerCli command.Streams, flags opt
 	}
 	if flags.dependencyTree {
 		opts = append(opts, provider.WithDependencyTree())
-	}
-	if flags.failOn != "" {
-		if flags.failOn != "all" && flags.failOn != "upgradable" && flags.failOn != "patchable" {
-			return nil, fmt.Errorf("--fail-on takes only 'all', 'upgradable' or 'patchable' values")
-		}
-		opts = append(opts, provider.WithFailOn(flags.failOn))
 	}
 	if flags.severity != "" {
 		if flags.severity != "low" && flags.severity != "medium" && flags.severity != "high" {

--- a/e2e/scan_test.go
+++ b/e2e/scan_test.go
@@ -264,42 +264,6 @@ func TestScanWithDependencies(t *testing.T) {
 	assert.Assert(t, strings.Contains(output, "vulnerability found"))
 }
 
-func TestScanWithFailOn(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("Can't run on this ci platform (windows containers or no engine installed)")
-	}
-	_, cleanFunction := createSnykConfFile(t, os.Getenv("E2E_TEST_AUTH_TOKEN"))
-	defer cleanFunction()
-
-	cmd, configDir, cleanup := dockerCli.createTestCmd()
-	defer cleanup()
-
-	createScanConfigFile(t, configDir)
-
-	cmd.Command = dockerCli.Command("scan", "--accept-license", "--fail-on", "upgradable", ImageWithVulnerabilities)
-	output := icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 0}).Combined()
-	assert.Assert(t, strings.Contains(output, "alpine:3.10.0")) // beginning of the dependency tree
-	assert.Assert(t, cmp.Regexp("found .* issues", output))
-}
-
-func TestScanWithFailOnBadValue(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		t.Skip("Can't run on this ci platform (windows containers or no engine installed)")
-	}
-	_, cleanFunction := createSnykConfFile(t, os.Getenv("E2E_TEST_AUTH_TOKEN"))
-	defer cleanFunction()
-
-	cmd, configDir, cleanup := dockerCli.createTestCmd()
-	defer cleanup()
-
-	createScanConfigFile(t, configDir)
-
-	cmd.Command = dockerCli.Command("scan", "--accept-license", "--fail-on", "unsupportedValue", ImageWithVulnerabilities)
-	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      "--fail-on takes only 'all', 'upgradable' or 'patchable' values"})
-}
-
 func TestScanWithSeverity(t *testing.T) {
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		t.Skip("Can't run on this ci platform (windows containers or no engine installed)")

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -8,8 +8,6 @@ Options:
       --dependency-tree   Show dependency tree with scan results
       --exclude-base      Exclude base image from vulnerability scanning
                           (requires --file)
-      --fail-on string    Only fail when there are vulnerabilities that
-                          can be fixed (all|upgradable|patchable)
   -f, --file string       Dockerfile associated with image, provides more
                           detailed results
       --json              Output results in JSON format

--- a/internal/provider/snyk.go
+++ b/internal/provider/snyk.go
@@ -136,14 +136,6 @@ func WithDependencyTree() SnykProviderOps {
 	}
 }
 
-// WithFailOn only fail when there are vulnerabilities that can be fixed
-func WithFailOn(failOn string) SnykProviderOps {
-	return func(provider *snykProvider) error {
-		provider.flags = append(provider.flags, "--fail-on="+failOn)
-		return nil
-	}
-}
-
 // WithSeverity only reports vulnerabilities of the provided level or higher
 func WithSeverity(severity string) SnykProviderOps {
 	return func(provider *snykProvider) error {


### PR DESCRIPTION

**- What I did**
Remove `--fails-on` flag which is always exiting the command with a success status when used with `container` command

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/101033950-9b235b80-357a-11eb-8199-f2e83d0405d8.png)

