### PR TITLE
Add native build make target to simplify docker-ce-packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ validate-go-mod: ## Validate go.mod and go.sum are up-to-date
 .PHONY: validate
 validate: validate-go-mod validate-headers ## Validate sources
 
+.PHONY: native-build
+native-build:
+	GO111MODULE=on make -f builder.Makefile build
+
 .PHONY: help
 help: ## Show help
 	@echo Please specify a build target. The choices are:

--- a/vars.mk
+++ b/vars.mk
@@ -15,5 +15,5 @@ BINARY_EXT=
 ifeq ($(GOOS),windows)
 	BINARY_EXT=.exe
 endif
-PLATFORM_BINARY:=docker-scan_$(GOOS)_amd64$(BINARY_EXT)
+PLATFORM_BINARY?=docker-scan_$(GOOS)_amd64$(BINARY_EXT)
 BINARY=docker-scan$(BINARY_EXT)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**- What I did**
Add native make target to simplify packaging and allow `PLATFORM_BINARY=docker-scan make native-build`

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

