### PR TITLE
Do not require accept-license to display version

### DIFF
--- a/cmd/docker-scan/main.go
+++ b/cmd/docker-scan/main.go
@@ -157,6 +157,9 @@ func checkConsent(flags options, dockerCli command.Streams) (config.Config, erro
 	if err != nil {
 		return config.Config{}, err
 	}
+	if flags.showVersion {
+		return conf, nil
+	}
 
 	if !conf.Optin || flags.forceOptIn || flags.forceOptOut {
 		switch {

--- a/e2e/optin_test.go
+++ b/e2e/optin_test.go
@@ -42,7 +42,7 @@ func TestFirstScanOptinMessage(t *testing.T) {
 	// docker scan should ask for consent the first time the user runs it
 	in, out, err := os.Pipe()
 	assert.NilError(t, err)
-	cmd.Command = dockerCli.Command("scan", "--version")
+	cmd.Command = dockerCli.Command("scan", "myimage")
 	cmd.Stdin = in
 
 	go func() {
@@ -51,8 +51,7 @@ func TestFirstScanOptinMessage(t *testing.T) {
 	}()
 
 	result := icmd.RunCmd(cmd)
-	assert.Assert(t, strings.Contains(result.Combined(), `Docker Scan relies upon access to Snyk, a third party provider, do you consent to proceed using Snyk? (y/N)
-Version:`))
+	assert.Assert(t, strings.Contains(result.Combined(), `Docker Scan relies upon access to Snyk, a third party provider, do you consent to proceed using Snyk? (y/N)`))
 
 	// check the consent has been stored in config file
 	data, err := ioutil.ReadFile(filepath.Join(configDir, "scan", "config.json"))
@@ -67,8 +66,8 @@ func TestRefuseOptinWithDisableFlag(t *testing.T) {
 	defer cleanup()
 	createScanConfigFile(t, configDir)
 
-	// docker scan --version should exit immediately
-	cmd.Command = dockerCli.Command("scan", "--reject-license", "--version")
+	// docker scan myimage should exit immediately
+	cmd.Command = dockerCli.Command("scan", "--reject-license", "myimage")
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		ExitCode: 0,
 		Out:      "",

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -83,7 +83,7 @@ func TestVersionSnykDesktopBinary(t *testing.T) {
 	createScanConfigFile(t, configDir)
 
 	// docker scan --version should print docker scan plugin version and snyk version
-	cmd.Command = dockerCli.Command("scan", "--accept-license", "--version")
+	cmd.Command = dockerCli.Command("scan", "--version")
 	output := icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined()
 	expected := fmt.Sprintf(
 		`Version:    %s
@@ -99,7 +99,7 @@ func TestVersionWithoutSnykOrConfig(t *testing.T) {
 	defer cleanup()
 
 	// docker scan --version should fail with a clean error
-	cmd.Command = dockerCli.Command("scan", "--accept-license", "--version")
+	cmd.Command = dockerCli.Command("scan", "--version")
 	res := icmd.RunCmd(cmd)
 	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" { // config file created by default without Docker Desktop
 		expected := fmt.Sprintf(`Version:    %s


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif guillaume.tardif@gmail.com
Fixes #144  

- What I did
  * Do not ask for license acceptation if option --version, just display version
  * Update e2e tests
