### PR TITLE
fix issue when using --file flag with the snyk containerized provider

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Download binaries
         run: make -f builder.Makefile download
 
-      - name: Build binary and run tests
-        run: make TAG_NAME=${{ github.event.inputs.tag }} -f builder.Makefile build e2e
+      - name: Build binary
+        run: make TAG_NAME=${{ github.event.inputs.tag }} -f builder.Makefile build
 
       - name: Build Cross
         run: make cross
@@ -68,7 +68,7 @@ jobs:
         run: make test-unit
 
       - name: End-to-end Tests
-        run: make e2e
+        run: make TAG_NAME=${{ github.event.inputs.tag }} -f builder.Makefile e2e
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v2

--- a/internal/provider/containerizedsnyk.go
+++ b/internal/provider/containerizedsnyk.go
@@ -268,6 +268,18 @@ func (d *dockerSnykProvider) newCommand(envVars []string, arg ...string) (string
 	bindings := dockerBindings{
 		"/var/run/docker.sock:/var/run/docker.sock",
 	}
+	for index, argument := range arg {
+		if strings.HasPrefix(argument, "--file") {
+			argSplit := strings.Split(argument, "=")
+			filePath, err := filepath.Abs(argSplit[1])
+			if err != nil {
+				return "", nil, err
+			}
+
+			bindings = append(bindings, fmt.Sprintf(`%s:/app/Dockerfile`, filePath))
+			arg[index] = "--file=/app/Dockerfile"
+		}
+	}
 	defaultEnvs := []string{"NO_UPDATE_NOTIFIER=true", "SNYK_CFG_DISABLESUGGESTIONS=true",
 		"SNYK_INTEGRATION_NAME=DOCKER_DESKTOP"}
 	envVars = append(envVars, defaultEnvs...)


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**- What I did**
Pass the Dockerfile to the Snyk Container when the `--file` flag is used

fix #153 

**- How I did it**
Mount the Dockerfile inside a volume with `/app/Dockerfile` as a target inside the container and change the `--file` target on the fly to match `/app/Dockerfile`
Add an e2e test to avoid regression

**- How to verify it**
e2e test should pass
On linux :
```
# Go to the scan-cli-plugin sources directory
$ docker scan --file ./e2e/testdata/Dockerfile dockerscanci/base-image-vulns:1.0

Testing dockerscanci/base-image-vulns:1.0...
...
Organization:      docker-desktop-test
Package manager:   apk
Target file:       ./e2e/testdata/Dockerfile
Project name:      docker-image|dockerscanci/base-image-vulns
Docker image:      dockerscanci/base-image-vulns:1.0
Platform:          linux/amd64
Base image:        alpine:3.10.0
Licenses:          enabled

Tested 14 dependencies for known issues, found 15 issues.

Base Image     Vulnerabilities  Severity
alpine:3.10.0  15               5 high, 7 medium, 3 low

Recommendations for base image upgrade:

Minor upgrades
Base Image   Vulnerabilities  Severity
alpine:3.11  0                0 high, 0 medium, 0 low
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/705411/116066739-a8a3c400-a688-11eb-951e-d0bc66643052.png)

