### PR TITLE
fix: remove NopCloser to get the right content-length set

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -47,7 +47,7 @@ func (h *Client) Login(hubAuthConfig types.AuthConfig) (string, error) {
 	body := bytes.NewBuffer(data)
 
 	// Login on the Docker Hub
-	req, err := http.NewRequest("POST", h.Domain+LoginURL, ioutil.NopCloser(body))
+	req, err := http.NewRequest("POST", h.Domain+LoginURL, body)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**- What I did**

Fix the way we login so `content-length` is set and login will succeed.

**- How I did it**

Removed the `ioutil.NopCloster`

**- How to verify it**

e2e tests are green

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

