### PR TITLE
Add --app-vulns flag only if no json output

### DIFF
--- a/cmd/docker-scan/main.go
+++ b/cmd/docker-scan/main.go
@@ -124,6 +124,8 @@ func configureProvider(ctx context.Context, dockerCli command.Cli, flags options
 		}
 	} else if flags.groupIssues {
 		return nil, fmt.Errorf("--json flag is mandatory to use --group-issues flag")
+	} else {
+		opts = append(opts, provider.WithAppVulns())
 	}
 	if flags.dockerFilePath != "" {
 		opts = append(opts, provider.WithDockerFile(flags.dockerFilePath))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -50,7 +50,7 @@ type Options struct {
 // NewProvider returns default provider options setup with the give options
 func NewProvider(options ...Ops) (Options, error) {
 	provider := Options{
-		flags: []string{"container", "test", "--app-vulns"},
+		flags: []string{"container", "test"},
 		out:   os.Stdout,
 		err:   os.Stderr,
 	}
@@ -147,6 +147,14 @@ func WithSeverity(severity string) Ops {
 func WithGroupIssues() Ops {
 	return func(provider *Options) error {
 		provider.flags = append(provider.flags, "--group-issues")
+		return nil
+	}
+}
+
+// WithAppVulns scans for applications vulnerabilities as well
+func WithAppVulns() Ops {
+	return func(provider *Options) error {
+		provider.flags = append(provider.flags, "--app-vulns")
 		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/scan-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Unfortunately the `--app-vulns` flag conflicts with `--json` flag. By default we add the `--app-vulns` flag, but don't add it when the `--json` flag is used.
This is a follow-up PR of #178 to fix the e2e tests.

**- How I did it**

**- How to verify it**

```
docker scan --accept-license --json hello-world
docker scan elastic/logstash:7.13.4 | grep "Arbitrary Code Execution"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

