### PR TITLE
Build mac arm64 binary

### DIFF
--- a/.github/workflows/release-weekly-build.yml
+++ b/.github/workflows/release-weekly-build.yml
@@ -75,6 +75,10 @@ jobs:
           E2E_HUB_TOKEN: ${{ secrets.E2E_HUB_TOKEN }}
         run: make TAG_NAME=${{ github.event.inputs.tag }} -f builder.Makefile build test-unit e2e
 
+      - name: Build Mac arm64 binary
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: make TAG_NAME=${{ github.event.inputs.tag }} -f builder.Makefile build-mac-arm64
+
       - name: Upload binary artifact
         if: ${{ github.event.inputs.tag != '' }} # don't push artifacts if no tag is specified
         uses: actions/upload-artifact@v2

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -60,7 +60,12 @@ test-unit:
 cross:
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) -o dist/docker-scan_linux_amd64 ./cmd/docker-scan
 	GOOS=darwin  GOARCH=amd64 $(GO_BUILD) -o dist/docker-scan_darwin_amd64 ./cmd/docker-scan
+	GOOS=darwin  GOARCH=arm64 $(GO_BUILD) -o dist/docker-scan_darwin_arm64 ./cmd/docker-scan
 	GOOS=windows GOARCH=amd64 $(GO_BUILD) -o dist/docker-scan_windows_amd64.exe ./cmd/docker-scan
+
+build-mac-arm64:
+	mkdir -p bin
+	GOOS=darwin GOARCH=arm64 $(GO_BUILD) -o bin/docker-scan_darwin_arm64 ./cmd/docker-scan
 
 .PHONY: build
 build:


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/scan-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Build a Mac arm64 binary for Docker Desktop to make `docker scan` work without Rosetta 2.

**- How I did it**

As GH actions runners don't have arm64 nodes, we have to cross build the binary.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

<img width="479" alt="Screenshot 2021-12-22 at 12 36 42" src="https://user-images.githubusercontent.com/207759/147086991-08a283ba-d18d-4c43-9a50-04f6975408f4.png">

