### PR TITLE
error message: Docker Login to docker login

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -187,7 +187,7 @@ func WithExperimental() Ops {
 func getToken(opts Options) (string, error) {
 	if opts.auth.Username == "" {
 		return "", fmt.Errorf(`You need to be logged in to Docker Hub to use scan feature.
-please login to Docker Hub using the Docker Login command`)
+please login to Docker Hub using the docker login command`)
 	}
 	h := hub.GetInstance()
 	jwks, err := h.FetchJwks()


### PR DESCRIPTION
"Docker Login" (-capitalized) is not valid command and if you copy & paste it's not going to work.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/scan-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
raplace 2 chars, "D" to "d" and "L" to "l".

**- How I did it**

**- How to verify it**

**- Description for the changelog**
replaced "Docker Login" with "docker login" in error message.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

