### PR TITLE
Replace backslashes with slashes to fix e2e run

### DIFF
--- a/builder.Makefile
+++ b/builder.Makefile
@@ -25,7 +25,7 @@ PWD:=$(shell pwd)
 ifeq ($(GOOS),windows)
 	SNYK_DOWNLOAD_NAME:=snyk-win.exe
 	SNYK_BINARY=snyk.exe
-	PWD=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+	PWD=$(subst \,/,$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))))
 endif
 ifeq ($(GOOS),darwin)
 	SNYK_DOWNLOAD_NAME:=snyk-macos


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/scan-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Make the `PWD` variable on Windows a path with forward slashes (again) instead of backslashes. I saw in [older workflow runs](https://github.com/docker/scan-cli-plugin/runs/6640002265?check_suite_focus=true#step:6:77) that the path used forward slashes, then [started failing](https://github.com/docker/scan-cli-plugin/runs/7594973993?check_suite_focus=true#step:6:79) running the e2e tests on Windows because of it having backslashes.

I was able to reproduce locally with MinGW64 11.2.0 installed:
```
$ mingw32-make -f builder.Makefile e2e
mkdir -p docker-config/scan
mkdir -p docker-config/cli-plugins
cp ./bin/docker-scan_windows_amd64.exe docker-config/cli-plugins/docker-scan.exe
# TODO: gotestsum doesn't forward ldflags to go test with golang 1.15.0, so moving back to go test temporarily
SNYK_DESKTOP_VERSION=1.827.0 SNYK_USER_VERSION=1.827.0 SNYK_OLD_VERSION=1.382.1 DOCKER_CONFIG=C:\code\scan-cli-plugin/docker-config SNYK_OLD_PATH=C:\code\scan-cli-plugin/docker-config/snyk-old SNYK_USER_PATH=C:\code\scan-cli-plugin/docker-config/snyk-user SNYK_DESKTOP_PATH=C:\code\scan-cli-plugin/docker-config/snyk-desktop go test ./e2e  -ldflags="-s -w -X github.com/docker/scan-cli-plugin/internal.GitCommit=5a67dc4 -X github.com/docker/scan-cli-plugin/internal.Version=v0.1.0-231-g5a67dc4185-dirty -X github.com/docker/scan-cli-plugin/internal/provider.ImageDigest=sha256:f9291a5310e3952369eeb8cd1c2a25f0c9fc930a3ccc88e1ea20956ad86b75a4 -X github.com/docker/scan-cli-plugin/internal/provider.SnykDesktopVersion=1.827.0"
panic: open C:codescan-cli-plugin\docker-config\cli-plugins\docker-scan.exe: The system cannot find the path specified.
```

**- How I did it**

Add a `subst` to replace all `\` with `/`. Surprisingly in the Makefile I didn't had to use things like double `\\` backslash, just a single one is fine here.

**- How to verify it**
- have MinGW 64 11.2.0 installed
- Run `mingw32-make -f builder.Makefile e2e` that failed for me without the substitution. With this fix it only complains about missing E2E vars, but it came across the path 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

