### PR TITLE
ci: cleanup already called by env

### DIFF
--- a/e2e/plugin_test.go
+++ b/e2e/plugin_test.go
@@ -62,7 +62,7 @@ sleep 1000`), 0700))
 
 	// Add mock snyk binary to the $PATH
 	path := os.Getenv("PATH")
-	defer env.Patch(t, "PATH", fmt.Sprintf(pathFormat(), configDir+"/scan", path))()
+	env.Patch(t, "PATH", fmt.Sprintf(pathFormat(), configDir+"/scan", path))()
 
 	cmd.Command = dockerCli.Command("scan", "--version")
 	icmd.StartCmd(cmd)


### PR DESCRIPTION
This causes failures on windows for the weekly build.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/scan-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

