### PR TITLE
tests: set PATH in cmd on windows

### DIFF
--- a/e2e/plugin_test.go
+++ b/e2e/plugin_test.go
@@ -62,9 +62,15 @@ sleep 1000`), 0700))
 
 	// Add mock snyk binary to the $PATH
 	path := os.Getenv("PATH")
-	env.Patch(t, "PATH", fmt.Sprintf(pathFormat(), configDir+"/scan", path))()
+	path = fmt.Sprintf(pathFormat(), configDir+"/scan", path)
+	env.Patch(t, "PATH", path)()
+	// force the env variable on command side on Windows
+	if runtime.GOOS == "windows" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", path))
+	}
 
 	cmd.Command = dockerCli.Command("scan", "--version")
+
 	icmd.StartCmd(cmd)
 	time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/scan-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Set the `PATH` environment variable in the test `cmd` under windows. It allows to make visible the `snyk` fake executable for test purposes.

**- How I did it**

**- How to verify it**

Weekly build and release job to be green.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

